### PR TITLE
Update CallStack-Spoofer.h

### DIFF
--- a/include/CallStack-Spoofer.h
+++ b/include/CallStack-Spoofer.h
@@ -37,7 +37,7 @@
 #ifdef _KERNEL_MODE
 #define SPOOF_CALL(ret_type,name) (CallSpoofer::SafeCall<ret_type,std::remove_reference_t<decltype(*name)>>(name))
 #else
-#define SPOOF_CALL(name) (CallSpoofer::SafeCall>(name))
+#define SPOOF_CALL(name) (CallSpoofer::SafeCall(name))
 #endif
 
 


### PR DESCRIPTION
You had this code:

`#define SPOOF_CALL(name) (CallSpoofer::SafeCall<(name))`

You just had a simple mistake by accidently placing a '<' character.

Just changed to this instead:
`#define SPOOF_CALL(name) (CallSpoofer::SafeCall(name))`